### PR TITLE
Fix for creating broken REST services

### DIFF
--- a/src/InputFilter/RestService/PostInputFilter.php
+++ b/src/InputFilter/RestService/PostInputFilter.php
@@ -47,7 +47,7 @@ class PostInputFilter extends InputFilter
      * Override isValid to provide conditional input checking
      * @return bool
      */
-    public function isValid()
+    public function isValid($context = null)
     {
         if (! $this->isValidService()) {
             return false;


### PR DESCRIPTION
On new installs and after updating composer Apigility fails with the error: 

```
Fatal error: Declaration of ZF\Apigility\Admin\InputFilter\RestService\PostInputFilter::isValid() must be compatible with Zend\InputFilter\BaseInputFilter::isValid($context = NULL) in /var/www/vendor/zfcampus/zf-apigility-admin/src/InputFilter/RestService/PostInputFilter.php on line 12
```

This patch simply adds the new signature so the Rest service can be built.